### PR TITLE
Add FBTEE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ To install locally, type (inside or outside a virtual environment):
 
     # pip install .
 
-The tool can then be run using the `edpopx` command.
+The tool can then be run using the `edpopx` command. (On Windows it may
+be that the `edpopx` command does not become available on the path. In that
+case you can also run it using the command `python -m edpop_explorer`.)
 
 For development purposes it may be better to use the `--editable` option:
 
@@ -37,9 +39,9 @@ particular record:
 
     # show 8
 
-To exit, type Ctrl+D or use the `exit` command:
+To exit, type Ctrl+D or use the `quit` command:
 
-    # exit
+    # quit
 
 ## Design
 
@@ -55,6 +57,7 @@ in the `readers` subpackage):
   - SRUReader
     - **GallicaReader** / GallicaRecord
     - **CERLThesaurusReader** / CERLThesaurusRecord
+    - **BibliopolisReader** / BibliopolisRecord
     - SRUMarc21Reader / Marc21Record
       - **HPBReader**
       - **VD16Reader**
@@ -62,3 +65,5 @@ in the `readers` subpackage):
       - **VD18Reader**
   - SparqlReader / SparqlRecord
     - **STCNReader**
+  - **SBTIReader** / SBTIRecord
+  - **FBTEEReader** / FBTEERecord

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -9,6 +9,7 @@ from edpop_explorer.readers.cerl_thesaurus import CERLThesaurusReader
 from edpop_explorer.readers.gallica import GallicaReader
 from edpop_explorer.readers.stcn import STCNReader
 from edpop_explorer.readers.sbtireader import SBTIReader
+from edpop_explorer.readers.fbtee import FBTEEReader
 
 
 class EDPOPXShell(cmd2.Cmd):
@@ -83,6 +84,10 @@ class EDPOPXShell(cmd2.Cmd):
     def do_sbti(self, args) -> None:
         'Scottish Book Trade Index'
         self._query(SBTIReader, args)
+
+    def do_fbtee(self, args) -> None:
+        'French Book Trade in Enlightenment Europe'
+        self._query(FBTEEReader, args)
 
     def _show_records(self, records: List[APIRecord],
                       start: int,

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -54,15 +54,14 @@ class FBTEEReader(APIReader):
                     f.write(response.content)
             except OSError as err:
                 raise APIException(
-                    'Error writing database file to disk: {}'.format(err)
+                    f'Error writing database file to disk: {err}'
                 )
         else:
             raise APIException(
-                'Error downloading database file from {}'
-                .format(self.DATABASE_URL)
+                f'Error downloading database file from {self.DATABASE_URL}'
             )
-        print('Successfully saved database to {}.'.format(self.database_file))
-        print('See license: {}'.format(self.DATABASE_LICENSE))
+        print(f'Successfully saved database to {self.database_file}.')
+        print(f'See license: {self.DATABASE_LICENSE}')
 
     def prepare_query(self, query: str):
         self.prepared_query = '%' + query + '%'

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -1,0 +1,75 @@
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field as dataclass_field
+from pathlib import Path
+import sqlite3
+import yaml
+
+from edpop_explorer.apireader import APIReader, APIRecord, APIException
+
+
+@dataclass
+class FBTEERecord(APIRecord):
+    data: Dict[str, str] = dataclass_field(default_factory=dict)
+    authors: List[Tuple[str, str]] = dataclass_field(default_factory=list)
+
+    def get_title(self) -> str:
+        return self.data.get('full_book_title', '(no title provided)')
+
+    def show_record(self) -> str:
+        return_string = yaml.safe_dump(self.data, allow_unicode=True)
+        if self.authors:
+            authorstrings = [x[0] + ' - ' + x[1] for x in self.authors]
+            return_string += '\nAuthors:\n' + '\n'.join(authorstrings)
+        return return_string
+
+    def __repr__(self):
+        return self.get_title()
+
+
+class FBTEEReader(APIReader):
+    DATABASE_FILE = Path(__file__).parent.parent / 'cl.sqlite3'
+
+    def __init__(self):
+        self.con = sqlite3.connect(str(self.DATABASE_FILE))
+
+    def prepare_query(self, query: str):
+        self.prepared_query = '%' + query + '%'
+
+    def fetch(self) -> List[FBTEERecord]:
+        if not self.prepared_query:
+            raise APIException('First call prepare_query method')
+
+        cur = self.con.cursor()
+        columns = [x[1] for x in cur.execute('PRAGMA table_info(books)')]
+        res = cur.execute(
+            'SELECT B.*, BA.author_code, A.author_name FROM books B '
+            'JOIN books_authors BA on B.book_code=BA.book_code '
+            'JOIN authors A on BA.author_code=A.author_code '
+            'WHERE full_book_title LIKE ? '
+            'ORDER BY B.book_code',
+            (self.prepared_query,)
+        )
+        self.records = []
+        last_book_code = ''
+        for row in res:
+            # Since we are joining with another table, a book may be repeated,
+            # so check if this is a new item
+            book_code: str = row[columns.index('book_code')]
+            if last_book_code != book_code:
+                record = FBTEERecord()
+                record.data = {}
+                for i in range(len(columns)):
+                    record.data[columns[i]] = row[i]
+                self.records.append(record)
+                last_book_code = book_code
+            # Add author_code and author_name to the last record
+            assert len(self.records) > 0
+            author_code = row[len(columns)]
+            author_name = row[len(columns) + 1]
+            self.records[-1].authors.append((author_code, author_name))
+        self.number_of_results = len(self.records)
+        self.number_fetched = self.number_of_results
+        self.fetching_exhausted = True
+
+    def fetch_next(self):
+        pass

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -17,6 +17,8 @@ class FBTEERecord(APIRecord):
 
     def show_record(self) -> str:
         return_string = yaml.safe_dump(self.data, allow_unicode=True)
+        if self.link:
+            return_string = self.link + '\n' + return_string
         if self.authors:
             authorstrings = [x[0] + ' - ' + x[1] for x in self.authors]
             return_string += '\nAuthors:\n' + '\n'.join(authorstrings)
@@ -28,6 +30,8 @@ class FBTEERecord(APIRecord):
 
 class FBTEEReader(APIReader):
     DATABASE_FILE = Path(__file__).parent.parent / 'cl.sqlite3'
+    FBTEE_LINK = 'http://fbtee.uws.edu.au/stn/interface/browse.php?t=book&' \
+        'id={}'
 
     def __init__(self):
         self.con = sqlite3.connect(str(self.DATABASE_FILE))
@@ -60,6 +64,7 @@ class FBTEEReader(APIReader):
                 record.data = {}
                 for i in range(len(columns)):
                     record.data[columns[i]] = row[i]
+                record.link = self.FBTEE_LINK.format(book_code)
                 self.records.append(record)
                 last_book_code = book_code
             # Add author_code and author_name to the last record

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -49,6 +49,7 @@ class FBTEEReader(APIReader):
         response = requests.get(self.DATABASE_URL)
         if response.ok:
             try:
+                self.database_file.parent.mkdir(exist_ok=True, parents=True)
                 with open(self.database_file, 'wb') as f:
                     f.write(response.content)
             except OSError as err:

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -74,7 +74,7 @@ class FBTEEReader(APIReader):
         columns = [x[1] for x in cur.execute('PRAGMA table_info(books)')]
         res = cur.execute(
             'SELECT B.*, BA.author_code, A.author_name FROM books B '
-            'JOIN books_authors BA on B.book_code=BA.book_code '
+            'LEFT OUTER JOIN books_authors BA on B.book_code=BA.book_code '
             'JOIN authors A on BA.author_code=A.author_code '
             'WHERE full_book_title LIKE ? '
             'ORDER BY B.book_code',

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -112,7 +112,7 @@ class SparqlReader(APIReader):
             query=query
         )
 
-    def fetch(self) -> List[APIRecord]:
+    def fetch(self):
         if not self.prepared_query:
             raise APIException('First call prepare_query method')
         self.wrapper.setQuery(self.prepared_query)
@@ -134,3 +134,6 @@ class SparqlReader(APIReader):
             )
             self.records.append(record)
         self.number_fetched = self.number_of_results
+
+    def fetch_next(self):
+        pass


### PR DESCRIPTION
Add a reader for FBTEE (French Book Trade in Enlightenment Europe, fbtee.uws.edu.au/main/). This is a complex relational database, so my suggestion is that EDPOP only gives access to the bibliographical data in the `books` table. The user can then see the full item by using the hyperlink to FBTEE's web interface.

FBTEE has no API but the reader automatically downloads the database as a SQLite file.

@ar-jan : I asked you to review because of the SQL parts; no need to understand the APIReader mechanism.