### PR TITLE
Add Bibliothèque nationale de France and VDLied

### DIFF
--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Type
 from edpop_explorer.apireader import APIReader, APIRecord, APIException
 from edpop_explorer.readers.hpb import HPBReader
 from edpop_explorer.readers.vd import VD16Reader, VD17Reader, VD18Reader
+from edpop_explorer.readers.bnf import BnFReader
 from edpop_explorer.readers.bibliopolis import BibliopolisReader
 from edpop_explorer.readers.cerl_thesaurus import CERLThesaurusReader
 from edpop_explorer.readers.gallica import GallicaReader
@@ -63,6 +64,10 @@ class EDPOPXShell(cmd2.Cmd):
         """Verzeichnis der im deutschen Sprachbereich erschienenen Drucke
         des 18. Jahrhunderts"""
         self._query(VD18Reader, args)
+
+    def do_bnf(self, args) -> None:
+        """Bibliothèque nationale de France"""
+        self._query(BnFReader, args)
 
     def do_gallica(self, args) -> None:
         'Gallica'

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Type
 
 from edpop_explorer.apireader import APIReader, APIRecord, APIException
 from edpop_explorer.readers.hpb import HPBReader
-from edpop_explorer.readers.vd import VD16Reader, VD17Reader, VD18Reader
+from edpop_explorer.readers.vd import VD16Reader, VD17Reader, VD18Reader, \
+    VDLiedReader
 from edpop_explorer.readers.bnf import BnFReader
 from edpop_explorer.readers.bibliopolis import BibliopolisReader
 from edpop_explorer.readers.cerl_thesaurus import CERLThesaurusReader
@@ -64,6 +65,10 @@ class EDPOPXShell(cmd2.Cmd):
         """Verzeichnis der im deutschen Sprachbereich erschienenen Drucke
         des 18. Jahrhunderts"""
         self._query(VD18Reader, args)
+
+    def do_vdlied(self, args) -> None:
+        """Verzeichnis der deutschsprachigen Liedflugschriften"""
+        self._query(VDLiedReader, args)
 
     def do_bnf(self, args) -> None:
         """Bibliothèque nationale de France"""

--- a/edpop_explorer/readers/bnf.py
+++ b/edpop_explorer/readers/bnf.py
@@ -10,7 +10,6 @@ class BnFReader(SRUMarc21Reader):
     marcxchange_prefix = 'info:lc/xmlns/marcxchange-v2:'
 
     def transform_query(self, query: str) -> str:
-        # return query
         return 'bib.anywhere all ({})'.format(query)
 
     def _convert_record(self, sruthirecord: dict) -> Marc21Record:
@@ -22,8 +21,5 @@ class BnFReader(SRUMarc21Reader):
         return record
 
     def get_link(self, record: Marc21Record) -> Optional[str]:
-        # The record id can be found in field 035 in subfield a starting
-        # with (CERL), like this: (CERL)HU-SzSEK.01.bibJAT603188.
-        # The URI can then be created using HPB_URI.
-        # HPB records have field 035 two times.
+        # The link can be found in control field 003
         return record.controlfields.get('003', None)

--- a/edpop_explorer/readers/bnf.py
+++ b/edpop_explorer/readers/bnf.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from edpop_explorer.srumarc21reader import SRUMarc21Reader, Marc21Record
+
+
+class BnFReader(SRUMarc21Reader):
+    sru_url = 'http://catalogue.bnf.fr/api/SRU'
+    sru_version = '1.2'
+    HPB_LINK = 'http://hpb.cerl.org/record/{}'
+    marcxchange_prefix = 'info:lc/xmlns/marcxchange-v2:'
+
+    def transform_query(self, query: str) -> str:
+        # return query
+        return 'bib.anywhere all ({})'.format(query)
+
+    def _convert_record(self, sruthirecord: dict) -> Marc21Record:
+        # Call inherited method, but change the title field
+        record = super()._convert_record(sruthirecord)
+        # For some reason BnF holds the main title in field 200, which
+        # normally does not exist in marc21.
+        record.title_field_subfield = ['200', 'a']
+        return record
+
+    def get_link(self, record: Marc21Record) -> Optional[str]:
+        # The record id can be found in field 035 in subfield a starting
+        # with (CERL), like this: (CERL)HU-SzSEK.01.bibJAT603188.
+        # The URI can then be created using HPB_URI.
+        # HPB records have field 035 two times.
+        return record.controlfields.get('003', None)

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -58,3 +58,15 @@ class VD18Reader(SRUMarc21Reader):
                     field.subfields['a'][5:]
                 )
         return None
+
+
+class VDLiedReader(SRUMarc21Reader):
+    sru_url = 'http://sru.gbv.de/vdlied'
+    sru_version = '1.1'
+    VDLIED_LINK = 'https://gso.gbv.de/DB=1.60/PPNSET?PPN={}'
+
+    def transform_query(self, query: str) -> str:
+        return query
+
+    def get_link(self, record: Marc21Record):
+        return self.VDLIED_LINK.format(record.controlfields['001'])

--- a/edpop_explorer/srumarc21reader.py
+++ b/edpop_explorer/srumarc21reader.py
@@ -49,7 +49,9 @@ class Marc21Record(APIRecord):
     # We use a list for the fields and not a dictionary because they may
     # appear more than once
     fields: List[Marc21RecordField] = dataclass_field(default_factory=list)
+    controlfields: Dict[str, str] = dataclass_field(default_factory=dict)
     link: Optional[str] = None
+    title_field_subfield = ['245', 'a']
 
     def get_first_field(self, fieldnumber: str) -> Marc21RecordField:
         '''Return the first occurance of a field with a given field number.
@@ -70,9 +72,12 @@ class Marc21Record(APIRecord):
         return returned_fields
 
     def get_title(self):
-        field_245 = self.get_first_field('245')
-        if field_245:
-            return field_245.subfields.get('a', '(unknown title)')
+        title_field = self.get_first_field(self.title_field_subfield[0])
+        if title_field:
+            return title_field.subfields.get(
+                self.title_field_subfield[1],
+                '(unknown title)'
+            )
         else:
             return '(unknown title)'
 
@@ -89,9 +94,16 @@ class Marc21Record(APIRecord):
 
 
 class SRUMarc21Reader(SRUReader):
-    def _convert_record(self, sruthirecord: dict) -> APIRecord:
+    marcxchange_prefix = ''
+
+    def _convert_record(self, sruthirecord: dict) -> Marc21Record:
         record = Marc21Record()
-        for sruthifield in sruthirecord['datafield']:
+        for sruthicontrolfield in \
+                sruthirecord[f'{self.marcxchange_prefix}controlfield']:
+            tag = sruthicontrolfield['tag']
+            text = sruthicontrolfield['text']
+            record.controlfields[tag] = text
+        for sruthifield in sruthirecord[f'{self.marcxchange_prefix}datafield']:
             fieldnumber = sruthifield['tag']
             field = Marc21RecordField(
                 fieldnumber=fieldnumber,
@@ -103,10 +115,12 @@ class SRUMarc21Reader(SRUReader):
                 field.description = translation_dictionary[fieldnumber]
             # If there are multiple subfields, sruthi puts it directly in
             # a dict, otherwise it uses a list of dicts
-            if type(sruthifield['subfield']) == dict:
-                sruthisubfields = [sruthifield['subfield']]
+            if type(sruthifield[f'{self.marcxchange_prefix}subfield']) == dict:
+                sruthisubfields = \
+                    [sruthifield[f'{self.marcxchange_prefix}subfield']]
             else:
-                sruthisubfields = sruthifield['subfield']
+                sruthisubfields = \
+                    sruthifield[f'{self.marcxchange_prefix}subfield']
             assert type(sruthisubfields) == list
             for sruthisubfield in sruthisubfields:
                 field.subfields[sruthisubfield['code']] = \
@@ -115,5 +129,5 @@ class SRUMarc21Reader(SRUReader):
         record.link = self.get_link(record)
         return record
 
-    def get_link(self, record: APIRecord) -> str:
+    def get_link(self, record: APIRecord) -> Optional[str]:
         raise NotImplementedError('Should be implemented by subclass')

--- a/edpop_explorer/srumarc21reader.py
+++ b/edpop_explorer/srumarc21reader.py
@@ -97,6 +97,18 @@ class SRUMarc21Reader(SRUReader):
     marcxchange_prefix = ''
     records: List[Marc21Record]
 
+    def _get_subfields(self, sruthifield) -> list:
+        # If there is only one subfield, sruthi puts it directly in
+        # a dict, otherwise it uses a list of dicts. Make sure that
+        # we always have a list.
+        subfielddata = sruthifield[f'{self.marcxchange_prefix}subfield']
+        if type(subfielddata) == dict:
+            sruthisubfields = [subfielddata]
+        else:
+            sruthisubfields = subfielddata
+        assert type(sruthisubfields) == list
+        return sruthisubfields
+
     def _convert_record(self, sruthirecord: dict) -> Marc21Record:
         record = Marc21Record()
         for sruthicontrolfield in \
@@ -114,15 +126,8 @@ class SRUMarc21Reader(SRUReader):
             )
             if fieldnumber in translation_dictionary:
                 field.description = translation_dictionary[fieldnumber]
-            # If there are multiple subfields, sruthi puts it directly in
-            # a dict, otherwise it uses a list of dicts
-            if type(sruthifield[f'{self.marcxchange_prefix}subfield']) == dict:
-                sruthisubfields = \
-                    [sruthifield[f'{self.marcxchange_prefix}subfield']]
-            else:
-                sruthisubfields = \
-                    sruthifield[f'{self.marcxchange_prefix}subfield']
-            assert type(sruthisubfields) == list
+            sruthisubfields = self._get_subfields(sruthifield)
+
             for sruthisubfield in sruthisubfields:
                 field.subfields[sruthisubfield['code']] = \
                     sruthisubfield['text']

--- a/edpop_explorer/srumarc21reader.py
+++ b/edpop_explorer/srumarc21reader.py
@@ -95,6 +95,7 @@ class Marc21Record(APIRecord):
 
 class SRUMarc21Reader(SRUReader):
     marcxchange_prefix = ''
+    records: List[Marc21Record]
 
     def _convert_record(self, sruthirecord: dict) -> Marc21Record:
         record = Marc21Record()

--- a/edpop_explorer/srureader.py
+++ b/edpop_explorer/srureader.py
@@ -24,7 +24,7 @@ class SRUReader(APIReader):
         try:
             response = sruthi.searchretrieve(
                 self.sru_url,
-                self.transform_query(self.prepared_query),
+                self.prepared_query,
                 start_record=start_record,
                 maximum_records=RECORDS_PER_PAGE,
                 sru_version=self.sru_version,

--- a/tests/test_srureader.py
+++ b/tests/test_srureader.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import patch
 import json
 from pathlib import Path
@@ -32,3 +31,5 @@ class TestSRUReader:
             'Subject Added Entry - Topical Term'
         # Field that occurs multiple times
         assert len(results[0].get_fields('500')) == 5
+        # Control field
+        assert results[0].controlfields['007'] == 'tu'


### PR DESCRIPTION
These are two regular SRU APIs with data in marc21. This includes a change to SRUMarc21Reader, which now also parses the control fields.

These APIs are not on the original list, but during the last meeting it turned out that BnF is important for EDPOP, while VDLied is useful to explore and easy to implement.