### PR TITLE
Add USTC and KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,15 @@ in the `readers` subpackage):
     - **GallicaReader** / GallicaRecord
     - **CERLThesaurusReader** / CERLThesaurusRecord
     - **BibliopolisReader** / BibliopolisRecord
+    - **KBReader** / KBRecord
     - SRUMarc21Reader / Marc21Record
       - **HPBReader**
       - **VD16Reader**
       - **VD17Reader**
       - **VD18Reader**
+      - **BnFReader**
   - SparqlReader / SparqlRecord
     - **STCNReader**
   - **SBTIReader** / SBTIRecord
   - **FBTEEReader** / FBTEERecord
+  - **USTCReader** / USTCRecord

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -12,6 +12,7 @@ from edpop_explorer.readers.gallica import GallicaReader
 from edpop_explorer.readers.stcn import STCNReader
 from edpop_explorer.readers.sbtireader import SBTIReader
 from edpop_explorer.readers.fbtee import FBTEEReader
+from edpop_explorer.readers.ustc import USTCReader
 
 
 class EDPOPXShell(cmd2.Cmd):
@@ -98,6 +99,10 @@ class EDPOPXShell(cmd2.Cmd):
     def do_fbtee(self, args) -> None:
         'French Book Trade in Enlightenment Europe'
         self._query(FBTEEReader, args)
+
+    def do_ustc(self, args) -> None:
+        'Universal Short Title Catalogue'
+        self._query(USTCReader, args)
 
     def _show_records(self, records: List[APIRecord],
                       start: int,

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -13,6 +13,7 @@ from edpop_explorer.readers.stcn import STCNReader
 from edpop_explorer.readers.sbtireader import SBTIReader
 from edpop_explorer.readers.fbtee import FBTEEReader
 from edpop_explorer.readers.ustc import USTCReader
+from edpop_explorer.readers.kb import KBReader
 
 
 class EDPOPXShell(cmd2.Cmd):
@@ -103,6 +104,10 @@ class EDPOPXShell(cmd2.Cmd):
     def do_ustc(self, args) -> None:
         'Universal Short Title Catalogue'
         self._query(USTCReader, args)
+
+    def do_kb(self, args) -> None:
+        'Koninklijke Bibliotheek'
+        self._query(KBReader, args)
 
     def _show_records(self, records: List[APIRecord],
                       start: int,

--- a/edpop_explorer/readers/README_USTC.md
+++ b/edpop_explorer/readers/README_USTC.md
@@ -1,0 +1,31 @@
+USTC is implemented as a SQLite3 database, which the user has to download
+before usage. The file is considerably large (370 MiB) so that a download
+on the fly is not provided (contrary to FBTEE, where the file is automatically
+downloaded).
+
+We receive USTC as a Microsoft Access database - currently only the Editions
+table. This can be converted to a SQLite3 database as follows:
+
+* Export the table to CSV format inside Microsoft Access
+* Fix encoding issues and convert to `utf-8`:
+
+  contents = open('<filename>.csv', 'rb').read() \
+      .decode('cp1252', errors='ignore')
+  open('<filename>-v2.csv', 'w').write(contents)
+
+* Convert to SQLite3 using `pandas` (`pandas` appears to be reading the file
+  without issues, except for one invalid line in my case)
+
+  import pandas as pd
+  data = pd.read_csv(
+      '<filename>-v2.csv',
+      sep=';',
+      on_bad_lines='warn',
+      low_memory=False
+  )
+  import sqlite3
+  cnx = sqlite3.connect('ustc.sqlite3')
+  data.to_sql(name='editions', con=cnx)
+
+This creates the database `ustc.sqlite3` with the table `editions`. This file
+can be put into the location that `USTCReader` will point at when run.

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, field as dataclass_field
+from typing import Optional
+import yaml
+from edpop_explorer.srumarc21reader import SRUReader, APIRecord
+
+
+@dataclass
+class KBRecord(APIRecord):
+    data: dict = dataclass_field(default_factory=dict)
+    identifier: Optional[str] = None
+
+    def get_title(self) -> str:
+        if 'title' in self.data:
+            title = self.data['title']
+            if type(title) == list:
+                # Title contains a list of strings if it consists of multiple
+                # parts
+                return ' : '.join(title)
+            else:
+                return title
+        else:
+            return '(no title defined)'
+
+    def show_record(self) -> str:
+        return_string = yaml.safe_dump(self.data, allow_unicode=True)
+        if self.link:
+            return_string = self.link + '\n' + return_string
+        return return_string
+
+
+class KBReader(SRUReader):
+    sru_url = 'http://jsru.kb.nl/sru'
+    sru_version = '1.2'
+    KB_LINK = 'https://webggc.oclc.org/cbs/DB=2.37/PPN?PPN={}'
+
+    def __init__(self):
+        super().__init__()
+        # Set in init method because dicts are mutable
+        self.additional_params = {
+            'x-collection': 'GGC'
+        }
+
+    def transform_query(self, query: str) -> str:
+        return query
+
+    def _find_ppn(self, data: dict):
+        """Try to find the PPN given the data that comes from the SRU server"""
+        # This seems to work fine; not thoroughly tested.
+        oaipmhidentifier = data.get('OaiPmhIdentifier', None)
+        PREFIX = 'GGC:AC:'
+        ppn = None
+        if oaipmhidentifier and oaipmhidentifier.startswith(PREFIX):
+            ppn = oaipmhidentifier[len(PREFIX):]
+        return ppn
+
+    def _convert_record(self, sruthirecord: dict) -> KBRecord:
+        record = KBRecord()
+        record.data = sruthirecord
+        record.identifier = self._find_ppn(record.data)
+        if record.identifier:
+            # Also here: it seems to work, but there may be records where
+            # it doesn't work...
+            # NOTE: there is often a URL in the `identifier' field as well,
+            # but not always, and it uses a `resolver', which is slower.
+            # But if we find records for which no link can be found this may
+            # be an alternative.
+            record.link = self.KB_LINK.format(record.identifier)
+        return record

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -46,11 +46,11 @@ class KBReader(SRUReader):
     def _find_ppn(self, data: dict):
         """Try to find the PPN given the data that comes from the SRU server"""
         # This seems to work fine; not thoroughly tested.
-        oaipmhidentifier = data.get('OaiPmhIdentifier', None)
+        oai_pmh_identifier = data.get('OaiPmhIdentifier', None)
         PREFIX = 'GGC:AC:'
         ppn = None
-        if oaipmhidentifier and oaipmhidentifier.startswith(PREFIX):
-            ppn = oaipmhidentifier[len(PREFIX):]
+        if oai_pmh_identifier and oai_pmh_identifier.startswith(PREFIX):
+            ppn = oai_pmh_identifier[len(PREFIX):]
         return ppn
 
     def _convert_record(self, sruthirecord: dict) -> KBRecord:

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -1,9 +1,8 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List
 from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
 import sqlite3
 import yaml
-import requests
 from appdirs import AppDirs
 
 from edpop_explorer.apireader import APIReader, APIRecord, APIException
@@ -50,6 +49,9 @@ class USTCReader(APIReader):
 
         cur = self.con.cursor()
         columns = [x[1] for x in cur.execute('PRAGMA table_info(editions)')]
+        # This kind of query is far from ideal, but the alternative is to
+        # implement SQLite full text search which is probably too much work
+        # for our current goal (i.e. getting insight in the data structures)
         res = cur.execute(
             'SELECT E.* FROM editions E '
             'WHERE E.std_title LIKE ? '

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -1,0 +1,79 @@
+from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field as dataclass_field
+from pathlib import Path
+import sqlite3
+import yaml
+import requests
+from appdirs import AppDirs
+
+from edpop_explorer.apireader import APIReader, APIRecord, APIException
+
+
+@dataclass
+class USTCRecord(APIRecord):
+    data: Dict[str, str] = dataclass_field(default_factory=dict)
+
+    def get_title(self) -> str:
+        return self.data.get('std_title', '(no title provided)')
+
+    def show_record(self) -> str:
+        return_string = yaml.safe_dump(self.data, allow_unicode=True)
+        if self.link:
+            return_string = self.link + '\n' + return_string
+        return return_string
+
+    def __repr__(self):
+        return self.get_title()
+
+
+class USTCReader(APIReader):
+    DATABASE_FILENAME = 'ustc.sqlite3'
+    USTC_LINK = 'https://www.ustc.ac.uk/editions/{}'
+
+    def __init__(self):
+        self.database_file = Path(
+            AppDirs('edpop-explorer', 'cdh').user_data_dir
+        ) / self.DATABASE_FILENAME
+        if not self.database_file.exists():
+            print(f'USTC database not found. Please download the file '
+                  f'{self.DATABASE_FILENAME} and add it to the following '
+                  f'directory: {self.database_file.parent}')
+            raise APIException('Database file not found')
+        self.con = sqlite3.connect(str(self.database_file))
+
+    def prepare_query(self, query: str):
+        self.prepared_query = '%' + query + '%'
+
+    def fetch(self) -> List[USTCRecord]:
+        if not self.prepared_query:
+            raise APIException('First call prepare_query method')
+
+        cur = self.con.cursor()
+        columns = [x[1] for x in cur.execute('PRAGMA table_info(editions)')]
+        res = cur.execute(
+            'SELECT E.* FROM editions E '
+            'WHERE E.std_title LIKE ? '
+            'OR E.author_name_1 LIKE ? '
+            'OR E.author_name_2 LIKE ? '
+            'OR E.author_name_3 LIKE ? '
+            'OR E.author_name_4 LIKE ? '
+            'OR E.author_name_5 LIKE ? '
+            'OR E.author_name_6 LIKE ? '
+            'OR E.author_name_7 LIKE ? '
+            'OR E.author_name_8 LIKE ? '
+            'ORDER BY E.id',
+            [self.prepared_query for _ in range(9)],
+        )
+        self.records = []
+        for row in res:
+            record = USTCRecord()
+            for i in range(len(columns)):
+                record.data[columns[i]] = row[i]
+            record.link = self.USTC_LINK.format(record.data['sn'])
+            self.records.append(record)
+        self.number_of_results = len(self.records)
+        self.number_fetched = self.number_of_results
+        self.fetching_exhausted = True
+
+    def fetch_next(self):
+        pass

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -34,9 +34,9 @@ class USTCReader(APIReader):
             AppDirs('edpop-explorer', 'cdh').user_data_dir
         ) / self.DATABASE_FILENAME
         if not self.database_file.exists():
-            print(f'USTC database not found. Please download the file '
-                  f'{self.DATABASE_FILENAME} and add it to the following '
-                  f'directory: {self.database_file.parent}')
+            print(f'USTC database not found. Please obtain the file '
+                  f'{self.DATABASE_FILENAME} from the project team and add it '
+                  f'to the following directory: {self.database_file.parent}')
             raise APIException('Database file not found')
         self.con = sqlite3.connect(str(self.database_file))
 


### PR DESCRIPTION
Add two more important databases: Universal Short Title Catalogue and Koninklijke Bibliotheek.

USTC is provided to us as a simple Microsoft Access Database. This had to be converted to a `sqlite3` database - see the readme file for details on conversion. Both the original and the converted database are available on our internal network for now. The way of querying is far from ideal, with `SQL LIKE` queries, but okay for now since we are considering using elasticsearch for searching these databases later.

The KB catalogue is a simple SRU interface to their main catalogue.