### PR TITLE
Feature/custom queries

### DIFF
--- a/edpop_explorer/apireader.py
+++ b/edpop_explorer/apireader.py
@@ -25,6 +25,10 @@ class APIReader:
     def prepare_query(self, query: str) -> None:
         raise NotImplementedError('Should be implemented by subclass')
 
+    def set_query(self, query: str) -> None:
+        '''Set an exact query'''
+        self.prepared_query = query
+
     def fetch(self):
         raise NotImplementedError('Should be implemented by subclass')
 

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -43,8 +43,11 @@ class EDPOPXShell(cmd2.Cmd):
         except (TypeError, ValueError):
             self.perror('Please provide a valid number')
             return None
+        record = self.reader.records[index]
+        if record.link:
+            self.pfeedback(cmd2.ansi.style_success(record.link, bold=True))
         try:
-            self.poutput(self.reader.records[index].show_record())
+            self.poutput(record.show_record())
         except IndexError:
             self.perror('Please provide a record number that has been loaded')
 

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -1,4 +1,5 @@
 import cmd2
+import math
 from typing import List, Optional, Type
 
 from edpop_explorer.apireader import APIReader, APIRecord, APIException
@@ -63,7 +64,7 @@ class EDPOPXShell(cmd2.Cmd):
         ))
         if record.link:
             self.poutput(cmd2.ansi.style_success(
-                'URL: ' + record.link, bold=True
+                'URL: ' + str(record.link), bold=True
             ))
         self.poutput(record.show_record())
 
@@ -128,7 +129,7 @@ class EDPOPXShell(cmd2.Cmd):
 
     def _show_records(self, records: List[APIRecord],
                       start: int,
-                      limit: Optional[int] = None) -> int:
+                      limit=math.inf) -> int:
         """Show the records from start, with limit as the maximum number
         of records to show. Return the number of records shown."""
         total = len(records)
@@ -136,10 +137,7 @@ class EDPOPXShell(cmd2.Cmd):
         if remaining < 1:
             return 0
         # Determine count (the number of items to show)
-        if limit is None:
-            count = remaining
-        else:
-            count = min(remaining, limit)
+        count = min(remaining, limit)
         digits = len(str(total))
         for i in range(start, start + count):
             print('{:{digits}} - {}'.format(

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -38,20 +38,26 @@ class EDPOPXShell(cmd2.Cmd):
     def do_show(self, args) -> None:
         if self.reader is None:
             self.perror('First perform an initial search')
-            return None
+            return
         try:
             # TODO: consider using argparse
             index = int(args) - 1
         except (TypeError, ValueError):
             self.perror('Please provide a valid number')
-            return None
-        record = self.reader.records[index]
-        if record.link:
-            self.pfeedback(cmd2.ansi.style_success(record.link, bold=True))
+            return
         try:
-            self.poutput(record.show_record())
+            record = self.reader.records[index]
         except IndexError:
             self.perror('Please provide a record number that has been loaded')
+            return
+        self.poutput(cmd2.ansi.style_success(
+            record.get_title(), bold=True
+        ))
+        if record.link:
+            self.poutput(cmd2.ansi.style_success(
+                'URL: ' + record.link, bold=True
+            ))
+        self.poutput(record.show_record())
 
     def do_hpb(self, args) -> None:
         'CERL\'s Heritage of the Printed Book Database'

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -19,7 +19,7 @@ from edpop_explorer.readers.kb import KBReader
 class EDPOPXShell(cmd2.Cmd):
     intro = 'Welcome to the EDPOP explorer! Type ‘help’ for help.\n'
     prompt = '[edpop-explorer] # '
-    reader: APIReader = None
+    reader: Optional[APIReader] = None
     shown: int = 0
     RECORDS_PER_PAGE = 10
 
@@ -129,7 +129,7 @@ class EDPOPXShell(cmd2.Cmd):
             return 0
         # Determine count (the number of items to show)
         if limit is None:
-            count = limit
+            count = remaining
         else:
             count = min(remaining, limit)
         digits = len(str(total))

--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -23,6 +23,14 @@ class EDPOPXShell(cmd2.Cmd):
     shown: int = 0
     RECORDS_PER_PAGE = 10
 
+    def __init__(self):
+        super().__init__()
+
+        self.exact = False
+        self.add_settable(cmd2.Settable(
+            'exact', bool, 'use exact queries without preprocessing', self
+        ))
+
     def do_next(self, args) -> None:
         if self.reader is None:
             self.perror('First perform an initial search')
@@ -143,10 +151,16 @@ class EDPOPXShell(cmd2.Cmd):
         self.reader = readerclass()
         self.shown = 0
         try:
-            self.reader.prepare_query(query)
-            self.pfeedback(
-                'Performing query: {}'.format(self.reader.prepared_query)
-            )
+            if not self.exact:
+                self.reader.prepare_query(query)
+                self.pfeedback(
+                    'Performing query: {}'.format(self.reader.prepared_query)
+                )
+            else:
+                self.reader.set_query(query)
+                self.pfeedback(
+                    'Performing exact query: {}'.format(query)
+                )
             self.reader.fetch()
         except APIException as err:
             self.perror('Error while fetching results: {}'.format(err))

--- a/edpop_explorer/readers/cerl_thesaurus.py
+++ b/edpop_explorer/readers/cerl_thesaurus.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict, List
 from termcolor import colored
 from textwrap import indent
 import pandas as pd
+import yaml
 
 
 @dataclass
@@ -19,6 +20,10 @@ class CERLThesaurusRecord(APIRecord):
             return '(no display name defined)'
 
     def show_record(self) -> str:
+        contents = yaml.safe_dump(self.data, allow_unicode=True)
+        if self.link:
+            contents = self.link + '\n' + contents
+        return contents
         field_strings = []
         if self.link:
             field_strings.append('URL: ' + self.link)

--- a/edpop_explorer/readers/cerl_thesaurus.py
+++ b/edpop_explorer/readers/cerl_thesaurus.py
@@ -25,8 +25,6 @@ class CERLThesaurusRecord(APIRecord):
             contents = self.link + '\n' + contents
         return contents
         field_strings = []
-        if self.link:
-            field_strings.append('URL: ' + self.link)
         for key in self.data:
             value = self.data[key]
             if type(value) == list:

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -19,8 +19,6 @@ class FBTEERecord(APIRecord):
 
     def show_record(self) -> str:
         return_string = yaml.safe_dump(self.data, allow_unicode=True)
-        if self.link:
-            return_string = self.link + '\n' + return_string
         if self.authors:
             authorstrings = [x[0] + ' - ' + x[1] for x in self.authors]
             return_string += '\nAuthors:\n' + '\n'.join(authorstrings)

--- a/edpop_explorer/readers/gallica.py
+++ b/edpop_explorer/readers/gallica.py
@@ -38,7 +38,21 @@ class GallicaReader(SRUReader):
 
     def _convert_record(self, sruthirecord: dict) -> GallicaRecord:
         record = GallicaRecord()
-        record.identifier = sruthirecord['identifier']
+        # identifier field contains visitable Gallica URL and possibly
+        # also other types of identifier. In the first case we get it as a
+        # string from sruthi, in the latter case as a list of strings.
+        # Take the first string starting with https:// as the identifier
+        # and as the link.
+        if type(sruthirecord['identifier']) == list:
+            identifiers = sruthirecord['identifier']
+        elif type(sruthirecord['identifier']) == str:
+            identifiers = [sruthirecord['identifier']]
+        else:
+            identifiers = []
+        for identifier in identifiers:
+            if identifier.startswith('https://'):
+                record.identifier = identifier
+                record.link = identifier
         record.link = record.identifier
         for key in sruthirecord:
             if key in ['schema', 'id']:

--- a/edpop_explorer/readers/gallica.py
+++ b/edpop_explorer/readers/gallica.py
@@ -18,8 +18,6 @@ class GallicaRecord(APIRecord):
 
     def show_record(self) -> str:
         field_strings = []
-        if self.link:
-            field_strings.append('URL: ' + self.link)
         for key in self.data:
             value = self.data[key]
             if type(value) == dict:

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -23,8 +23,6 @@ class KBRecord(APIRecord):
 
     def show_record(self) -> str:
         return_string = yaml.safe_dump(self.data, allow_unicode=True)
-        if self.link:
-            return_string = self.link + '\n' + return_string
         return return_string
 
 

--- a/edpop_explorer/readers/sbtireader.py
+++ b/edpop_explorer/readers/sbtireader.py
@@ -15,8 +15,6 @@ class SBTIRecord(APIRecord):
 
     def show_record(self) -> str:
         contents = yaml.safe_dump(self.data)
-        if self.link:
-            contents = self.link + '\n' + contents
         return contents
 
     def get_title(self) -> str:

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -17,8 +17,6 @@ class USTCRecord(APIRecord):
 
     def show_record(self) -> str:
         return_string = yaml.safe_dump(self.data, allow_unicode=True)
-        if self.link:
-            return_string = self.link + '\n' + return_string
         return return_string
 
     def __repr__(self):

--- a/edpop_explorer/srumarc21reader.py
+++ b/edpop_explorer/srumarc21reader.py
@@ -143,5 +143,5 @@ class SRUMarc21Reader(SRUReader):
         record.link = self.get_link(record)
         return record
 
-    def get_link(self, record: APIRecord) -> Optional[str]:
+    def get_link(self, record: Marc21Record) -> Optional[str]:
         raise NotImplementedError('Should be implemented by subclass')

--- a/edpop_explorer/srumarc21reader.py
+++ b/edpop_explorer/srumarc21reader.py
@@ -83,8 +83,6 @@ class Marc21Record(APIRecord):
 
     def show_record(self) -> str:
         field_strings = []
-        if self.link:
-            field_strings.append('URL: ' + self.link)
         for field in self.fields:
             field_strings.append(str(field))
         return '\n'.join(field_strings)


### PR DESCRIPTION
Small updates in user interface:

* Make shell responsible for showing title of records, so that it can be printed in a different colour for clarity
* Allow inputting exact queries (switch on with `set exact True`) (e.g., in the case of Gallica, do not change "book" to "gallica all book", but allow custom tweaking)