### PR TITLE
Allow requesting specific records by ID

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
     'Field', 'FieldError', 'LocationField',
     'Reader', 'ReaderError',
+    'GetByIdBasedOnQueryMixin',
     'Record', 'RawData', 'RecordError', 'BibliographicalRecord',
     'BiographicalRecord', 'LazyRecordMixin',
     'SRUReader',
@@ -18,7 +19,7 @@ BIOGRAPHICAL = "biographical"
 from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
 from .fields import Field, FieldError, LocationField
 from .reader import (
-    Reader, ReaderError
+    Reader, ReaderError, GetByIdBasedOnQueryMixin
 )
 from .record import (
     Record, RawData, RecordError, BibliographicalRecord, BiographicalRecord,

--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -1,7 +1,7 @@
 __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
     'Field', 'FieldError', 'LocationField',
-    'Reader', 'ReaderError',
+    'Reader', 'ReaderError', 'NotFoundError',
     'GetByIdBasedOnQueryMixin', 'PreparedQuery', 'PreparedQueryType',
     'Record', 'RawData', 'RecordError', 'BibliographicalRecord',
     'BiographicalRecord', 'LazyRecordMixin',
@@ -20,7 +20,7 @@ from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
 from .fields import Field, FieldError, LocationField
 from .reader import (
     Reader, ReaderError, GetByIdBasedOnQueryMixin, PreparedQuery,
-    PreparedQueryType
+    PreparedQueryType, NotFoundError
 )
 from .record import (
     Record, RawData, RecordError, BibliographicalRecord, BiographicalRecord,

--- a/edpop_explorer/__init__.py
+++ b/edpop_explorer/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     'EDPOPREC', 'RELATORS', 'bind_common_namespaces',
     'Field', 'FieldError', 'LocationField',
     'Reader', 'ReaderError',
-    'GetByIdBasedOnQueryMixin',
+    'GetByIdBasedOnQueryMixin', 'PreparedQuery', 'PreparedQueryType',
     'Record', 'RawData', 'RecordError', 'BibliographicalRecord',
     'BiographicalRecord', 'LazyRecordMixin',
     'SRUReader',
@@ -19,7 +19,8 @@ BIOGRAPHICAL = "biographical"
 from .rdf import EDPOPREC, RELATORS, bind_common_namespaces
 from .fields import Field, FieldError, LocationField
 from .reader import (
-    Reader, ReaderError, GetByIdBasedOnQueryMixin
+    Reader, ReaderError, GetByIdBasedOnQueryMixin, PreparedQuery,
+    PreparedQueryType
 )
 from .record import (
     Record, RawData, RecordError, BibliographicalRecord, BiographicalRecord,

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -1,11 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from dataclasses import dataclass
+from typing import Optional, List, Union
 from rdflib import Graph, RDF, URIRef
 
 from edpop_explorer import (
     EDPOPREC, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces
 )
 from .record import Record
+
+
+@dataclass
+class PreparedQuery:
+    pass
+
+
+PreparedQueryType = Union[str, PreparedQuery]
 
 
 class Reader(ABC):
@@ -34,7 +43,7 @@ class Reader(ABC):
     records: List[Record]
     '''The records that have been fetched as instances of
     (a subclass of) ``Record``.'''
-    prepared_query: Optional[str] = None
+    prepared_query: Optional[PreparedQueryType] = None
     '''A transformed version of the query, available after
     calling ``prepare_query()`` or ``set_query``.'''
     READERTYPE: Optional[str] = None
@@ -50,7 +59,7 @@ class Reader(ABC):
 
     @classmethod
     @abstractmethod
-    def transform_query(cls, query: str) -> str:
+    def transform_query(cls, query: str) -> PreparedQueryType:
         '''Return a version of the query that is prepared for use in the
         API.
 
@@ -63,7 +72,7 @@ class Reader(ABC):
         ``prepared_query`` attribute.'''
         self.prepared_query = self.transform_query(query)
 
-    def set_query(self, query: str) -> None:
+    def set_query(self, query: PreparedQueryType) -> None:
         '''Set an exact query. Updates the ``prepared_query``
         attribute.'''
         self.prepared_query = query
@@ -158,7 +167,7 @@ class GetByIdBasedOnQueryMixin(ABC):
 
     @classmethod
     @abstractmethod
-    def _prepare_get_by_id_query(cls, identifier: str) -> str:
+    def _prepare_get_by_id_query(cls, identifier: str) -> PreparedQueryType:
         pass
 
 

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -48,8 +48,9 @@ class Reader(ABC):
     overridden.'''
     _graph: Optional[Graph] = None
 
+    @classmethod
     @abstractmethod
-    def transform_query(self, query: str) -> str:
+    def transform_query(cls, query: str) -> str:
         '''Return a version of the query that is prepared for use in the
         API.
 

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -70,6 +70,7 @@ class Reader(ABC):
     @abstractmethod
     def fetch(self):
         '''Perform an initial query.'''
+        pass
 
     @abstractmethod
     def fetch_next(self):
@@ -80,6 +81,7 @@ class Reader(ABC):
     @abstractmethod
     def get_by_id(cls, identifier: str) -> Record:
         '''Get a single record by its identifier.'''
+        pass
 
     @classmethod
     def get_by_iri(cls, iri: str) -> Record:
@@ -134,6 +136,29 @@ class Reader(ABC):
         bind_common_namespaces(g)
         
         return g
+
+
+class GetByIdBasedOnQueryMixin(ABC):
+    @classmethod
+    def get_by_id(cls, identifier: str) -> Record:
+        reader = cls()
+        assert isinstance(reader, Reader), \
+            "GetByIdBasedOnQueryMixin should be used on Reader subclass"
+        reader.set_query(cls._prepare_get_by_id_query(identifier))
+        reader.fetch()
+        if reader.number_of_results == 1:
+            return reader.records[0]
+        elif reader.number_of_results == 0:
+            raise ReaderError("No results returned")
+        else:
+            raise ReaderError(
+                f"Multiple ({reader.number_of_results}) results returned."
+            )
+
+    @classmethod
+    @abstractmethod
+    def _prepare_get_by_id_query(cls, identifier: str) -> str:
+        pass
 
 
 class ReaderError(Exception):

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -156,14 +156,17 @@ class GetByIdBasedOnQueryMixin(ABC):
             "GetByIdBasedOnQueryMixin should be used on Reader subclass"
         reader.set_query(cls._prepare_get_by_id_query(identifier))
         reader.fetch()
-        if reader.number_of_results == 1:
-            return reader.records[0]
-        elif reader.number_of_results == 0:
+        if reader.number_of_results == 0:
             raise ReaderError("No results returned")
-        else:
-            raise ReaderError(
-                f"Multiple ({reader.number_of_results}) results returned."
-            )
+        for record in reader.records:
+            if record.identifier == identifier:
+                return record
+        # Record with correct ID was not returned in first fetch -
+        # give up.
+        raise ReaderError(
+            f"Record with identifier {identifier} not present among "
+            f"{reader.number_of_results} returned results."
+        )
 
     @classmethod
     @abstractmethod
@@ -172,4 +175,8 @@ class GetByIdBasedOnQueryMixin(ABC):
 
 
 class ReaderError(Exception):
+    pass
+
+
+class NotFoundError(ReaderError):
     pass

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -73,6 +73,12 @@ class Reader(ABC):
         pass
 
     @classmethod
+    def get_by_id(cls, identifier: str) -> Record:
+        '''Get a single record by its identifier.'''
+        # Not yet implemented, but implementation should be here
+        raise NotImplementedError
+
+    @classmethod
     def catalog_to_graph(cls) -> Graph:
         '''Create an RDF representation of the catalog that this reader
         supports as an instance of EDPOPREC:Catalog.'''

--- a/edpop_explorer/readers/__init__.py
+++ b/edpop_explorer/readers/__init__.py
@@ -19,6 +19,8 @@ __all__ = [
     "ALL_READERS",
 ]
 
+from edpop_explorer import Reader
+
 from .bibliopolis import BibliopolisReader
 from .bnf import BnFReader
 from .cerl_thesaurus import CERLThesaurusReader
@@ -35,11 +37,11 @@ import sys
 from typing import List, Type
 
 
-def _get_all_readers() -> List[Type]:
+def _get_all_readers() -> List[Type[Reader]]:
     """Create a list of all reader classes included in this package."""
     all_names = __all__.copy()
     all_names.pop()  # Remove "ALL_READERS" itself
-    all_readers: List[str] = []
+    all_readers: List[Type[Reader]] = []
     for name in all_names:
         cls = getattr(sys.modules[__name__], name, None)
         if cls is not None:

--- a/edpop_explorer/readers/__init__.py
+++ b/edpop_explorer/readers/__init__.py
@@ -1,7 +1,6 @@
 '''This package contains concrete subclasses of ``Reader``.'''
 
 __all__ = [
-    "BibliopolisReader",
     "BnFReader",
     "CERLThesaurusReader",
     "FBTEEReader",
@@ -9,7 +8,6 @@ __all__ = [
     "HPBReader",
     "KBReader",
     "SBTIReader",
-    "USTCReader",
     "VD16Reader",
     "VD17Reader",
     "VD18Reader",
@@ -21,7 +19,6 @@ __all__ = [
 
 from edpop_explorer import Reader
 
-from .bibliopolis import BibliopolisReader
 from .bnf import BnFReader
 from .cerl_thesaurus import CERLThesaurusReader
 from .fbtee import FBTEEReader

--- a/edpop_explorer/readers/bibliopolis.py
+++ b/edpop_explorer/readers/bibliopolis.py
@@ -1,3 +1,4 @@
+from rdflib import URIRef
 from edpop_explorer import Record, SRUReader
 
 
@@ -5,6 +6,10 @@ class BibliopolisReader(SRUReader):
     sru_url = 'http://jsru.kb.nl/sru/sru'
     sru_version = '1.2'
     HPB_LINK = 'http://hpb.cerl.org/record/{}'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/bibliopolis'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/bibliopolis/"
 
     def __init__(self):
         super().__init__()
@@ -18,5 +23,6 @@ class BibliopolisReader(SRUReader):
         # TODO: extract fields
         return record
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query

--- a/edpop_explorer/readers/bnf.py
+++ b/edpop_explorer/readers/bnf.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from rdflib import URIRef
+
 from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data
 
 
@@ -8,6 +10,10 @@ class BnFReader(SRUMarc21BibliographicalReader):
     sru_version = '1.2'
     HPB_LINK = 'http://hpb.cerl.org/record/{}'
     marcxchange_prefix = 'info:lc/xmlns/marcxchange-v2:'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/bnf'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/bnf/"
     _title_field_subfield = ('200', 'a')
     _alternative_title_field_subfield = ('500', 'a')
     _publisher_field_subfield = ('201', 'c')
@@ -16,7 +22,8 @@ class BnFReader(SRUMarc21BibliographicalReader):
     _language_field_subfield = ('101', 'a')
     # TODO: add format etc
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return 'bib.anywhere all ({})'.format(query)
 
     @classmethod
@@ -25,6 +32,9 @@ class BnFReader(SRUMarc21BibliographicalReader):
         return data.controlfields.get('003', None)
 
     @classmethod
+    def _prepare_get_by_id_query(cls, identifier: str) -> str:
+        return f'bib.anywhere all ("{identifier}")'
+
+    @classmethod
     def _get_identifier(cls, data: Marc21Data) -> Optional[str]:
-        # TODO
-        return None
+        return data.raw["id"]

--- a/edpop_explorer/readers/cerl_thesaurus.py
+++ b/edpop_explorer/readers/cerl_thesaurus.py
@@ -1,4 +1,6 @@
 from typing import Dict, List
+
+from rdflib import URIRef
 from edpop_explorer import SRUReader, Record, BiographicalRecord, Field
 from edpop_explorer.fields import LocationField
 
@@ -8,6 +10,10 @@ class CERLThesaurusReader(SRUReader):
     sru_version = '1.2'
     CERL_LINK = 'https://data.cerl.org/thesaurus/{}'
     CTAS_PREFIX = 'http://sru.cerl.org/ctas/dtd/1.1:'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/cerlthesaurus'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/cerlthesaurus/"
 
     @classmethod
     def _get_acceptable_names(
@@ -70,5 +76,6 @@ class CERLThesaurusReader(SRUReader):
 
         return record
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -1,21 +1,29 @@
 from pathlib import Path
 import sqlite3
+from rdflib import URIRef
 import requests
 from appdirs import AppDirs
-from typing import List
+from typing import List, Optional
 
 from edpop_explorer import (
     Reader, BibliographicalRecord, ReaderError, Field, BIBLIOGRAPHICAL
 )
+from edpop_explorer.reader import GetByIdBasedOnQueryMixin
+from edpop_explorer.sql import SQLPreparedQuery
 
 
-class FBTEEReader(Reader):
+class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
     DATABASE_URL = 'https://dhstatic.hum.uu.nl/edpop/cl.sqlite3'
     DATABASE_LICENSE = 'https://dhstatic.hum.uu.nl/edpop/LICENSE.txt'
     FBTEE_LINK = 'http://fbtee.uws.edu.au/stn/interface/browse.php?t=book&' \
         'id={}'
     records: List[BibliographicalRecord]
     READERTYPE = BIBLIOGRAPHICAL
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/fbtee'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/fbtee/"
+    prepared_query: Optional[SQLPreparedQuery] = None
 
     def __init__(self):
         self.database_file = Path(
@@ -44,8 +52,19 @@ class FBTEEReader(Reader):
         print(f'Successfully saved database to {self.database_file}.')
         print(f'See license: {self.DATABASE_LICENSE}')
 
-    def transform_query(self, query: str) -> str:
-        return '%' + query + '%'
+    @classmethod
+    def _prepare_get_by_id_query(cls, identifier: str) -> SQLPreparedQuery:
+        return SQLPreparedQuery(
+            where_statement="WHERE book_code = ?",
+            arguments=[identifier]
+        )
+
+    @classmethod
+    def transform_query(cls, query: str) -> SQLPreparedQuery:
+        return SQLPreparedQuery(
+            where_statement='WHERE full_book_title LIKE ?',
+            arguments=[f'%{query}%']
+        )
 
     @classmethod
     def _add_fields(cls, record: BibliographicalRecord) -> None:
@@ -71,7 +90,6 @@ class FBTEEReader(Reader):
             # author is tuple of author code and author name
             record.contributors.append(Field(author[1]))
 
-
     def fetch(self) -> None:
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
@@ -82,9 +100,9 @@ class FBTEEReader(Reader):
             'SELECT B.*, BA.author_code, A.author_name FROM books B '
             'LEFT OUTER JOIN books_authors BA on B.book_code=BA.book_code '
             'JOIN authors A on BA.author_code=A.author_code '
-            'WHERE full_book_title LIKE ? '
+            f'{self.prepared_query.where_statement} '
             'ORDER BY B.book_code',
-            (self.prepared_query,)
+            self.prepared_query.arguments
         )
         self.records = []
         last_book_code = ''

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -29,6 +29,8 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
         self.database_file = Path(
             AppDirs('edpop-explorer', 'cdh').user_data_dir
         ) / 'cl.sqlite3'
+
+    def prepare_data(self):
         if not self.database_file.exists():
             self._download_database()
         self.con = sqlite3.connect(str(self.database_file))
@@ -91,6 +93,7 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             record.contributors.append(Field(author[1]))
 
     def fetch(self) -> None:
+        self.prepare_data()
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
 

--- a/edpop_explorer/readers/hpb.py
+++ b/edpop_explorer/readers/hpb.py
@@ -11,12 +11,18 @@ class HPBReader(SRUMarc21BibliographicalReader):
     sru_version = '1.1'
     HPB_LINK = 'http://hpb.cerl.org/record/{}'
     CATALOG_URIREF = URIRef(
-        'https://dhstatic.hum.uu.nl/edpop-explorer/catalogs/hpb'
+        'https://edpop.hum.uu.nl/readers/hpb'
     )
     READERTYPE = BIBLIOGRAPHICAL
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/hpb/"
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
+
+    @classmethod
+    def _prepare_get_by_id_query(cls, identifier: str) -> str:
+        return f"pica.cid={identifier}"
 
     @classmethod
     def _get_identifier(cls, data:Marc21Data) -> Optional[str]:

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -9,9 +9,10 @@ class KBReader(SRUReader):
     sru_version = '1.2'
     KB_LINK = 'https://webggc.oclc.org/cbs/DB=2.37/PPN?PPN={}'
     CATALOG_URIREF = URIRef(
-        'https://dhstatic.hum.uu.nl/edpop-explorer/catalogs/kb'
+        'https://edpop.hum.uu.nl/readers/kb'
     )
     READERTYPE = BIBLIOGRAPHICAL
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/kb/"
 
     def __init__(self):
         super().__init__()
@@ -20,7 +21,8 @@ class KBReader(SRUReader):
             'x-collection': 'GGC'
         }
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
 
     def _find_ppn(self, data: dict):

--- a/edpop_explorer/readers/kb.py
+++ b/edpop_explorer/readers/kb.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 from rdflib import URIRef
 from edpop_explorer import SRUReader, BibliographicalRecord, BIBLIOGRAPHICAL
 from edpop_explorer import Field
@@ -66,7 +66,7 @@ class KBReader(SRUReader):
         else:
             return None
 
-    def _get_languages(self, data) -> Optional[list[Field]]:
+    def _get_languages(self, data) -> Optional[List[Field]]:
         # The 'language' field contains a list of languages, where every
         # language is repeated multiple times in different languages.
         # One of them is always a three-letter language code, so only

--- a/edpop_explorer/readers/stcn.py
+++ b/edpop_explorer/readers/stcn.py
@@ -26,6 +26,10 @@ class STCNReader(SparqlReader):
     filter = '?s schema:mainEntityOfPage/schema:isPartOf ' \
         '<http://data.bibliotheken.nl/id/dataset/stcn> .'
     name_predicate = '<http://schema.org/name>'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/stcn'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/stcn/"
 
     def __init__(self):
         super().__init__()

--- a/edpop_explorer/readers/stcn.py
+++ b/edpop_explorer/readers/stcn.py
@@ -1,6 +1,6 @@
 from rdflib import Graph, Namespace, URIRef
 from rdflib.term import Node
-from typing import List
+from typing import List, Optional, Tuple
 
 from edpop_explorer import Field
 from edpop_explorer.sparqlreader import (
@@ -8,7 +8,8 @@ from edpop_explorer.sparqlreader import (
 )
 
 
-def _get_properties_from_iri(iri: str, properties: List[Node]) -> (List[Node], Graph):
+def _get_properties_from_iri(iri: str, properties: List[Node]) -> \
+        Tuple[List[Node], Graph]:
     '''Get the first objects of the requested properties of a certain IRI
     as strings.'''
     subject_graph = Graph()
@@ -84,10 +85,10 @@ class STCNReader(SparqlReader):
 
     @classmethod
     def _create_lazy_record(
-        cls, iri: str, name: str
+        cls, iri: str, name: Optional[str]=None
     ) -> BibliographicalRDFRecord:
         record = BibliographicalRDFRecord(cls)
         record.identifier = iri
         record.link = iri
-        record.title = Field(name)
+        record.title = Field(name) if name else None
         return record

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -25,6 +25,8 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
         self.database_file = Path(
             AppDirs('edpop-explorer', 'cdh').user_data_dir
         ) / self.DATABASE_FILENAME
+
+    def prepare_data(self):
         if not self.database_file.exists():
             # Find database dir with .resolve() because on Windows it is
             # some sort of hidden symlink if Python was installed using
@@ -65,6 +67,8 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
         )
 
     def fetch(self) -> None:
+        self.prepare_data()
+
         # This method fetches all records immediately, because the data is
         # locally stored.
 

--- a/edpop_explorer/readers/vd.py
+++ b/edpop_explorer/readers/vd.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from rdflib import URIRef
+
 from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data
 
 
@@ -21,17 +23,20 @@ class VDCommonMixin():
             return cls.LINK_FORMAT.format(identifier).replace(' ', '+')
 
 
-
 class VD16Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
     sru_url = 'http://bvbr.bib-bvb.de:5661/bvb01sru'
     sru_version = '1.1'
     LINK_FORMAT = 'http://gateway-bayern.de/{}'  # Spaces should be replaced by +
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/vd16'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd16/"
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         # This SRU URL combines multiple databases, so make sure only VD16 is
         # queried
         return 'VD16 and ({})'.format(query)
-
 
 
 class VD17Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
@@ -39,8 +44,13 @@ class VD17Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
     sru_version = '1.1'
     LINK_FORMAT = \
         'https://kxp.k10plus.de/DB=1.28/CMD?ACT=SRCHA&IKT=8079&TRM=%27{}%27'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/vd17'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd17/"
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
 
 
@@ -50,8 +60,13 @@ class VD18Reader(VDCommonMixin, SRUMarc21BibliographicalReader):
     LINK_FORMAT = 'https://kxp.k10plus.de/DB=1.65/SET=1/TTL=1/CMD?ACT=SRCHA&' \
         'IKT=1016&SRT=YOP&TRM={}&ADI_MAT=B&MATCFILTER=Y&MATCSET=Y&ADI_MAT=T&' \
         'REC=*'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/vd18'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vd18/"
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
 
     @classmethod
@@ -71,8 +86,13 @@ class VDLiedReader(VDCommonMixin, SRUMarc21BibliographicalReader):
     sru_url = 'http://sru.k10plus.de/vdlied'
     sru_version = '1.1'
     LINK_FORMAT = 'https://gso.gbv.de/DB=1.60/PPNSET?PPN={}'
+    CATALOG_URIREF = URIRef(
+        'https://edpop.hum.uu.nl/readers/vdlied'
+    )
+    IRI_PREFIX = "https://edpop.hum.uu.nl/readers/vdlied/"
 
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
 
     @classmethod

--- a/edpop_explorer/record.py
+++ b/edpop_explorer/record.py
@@ -61,16 +61,14 @@ class Record:
     identifier: Optional[str] = None
     '''Unique identifier used by the source catalog.'''
     from_reader: Type["Reader"]
-    '''The Reader class that created the record.'''
-    subject_node: Node
     '''The subject node, which will be used to convert the record to 
     RDF. This is a blank node by default.'''
     _graph: Optional[Graph] = None
+    _bnode: Optional[BNode] = None
 
     def __init__(self, from_reader: Type["Reader"]):
         self._fields = []
         self.from_reader = from_reader
-        self.subject_node = BNode()
 
     def to_graph(self) -> Graph:
         '''Return an RDF graph for this record.'''
@@ -167,6 +165,28 @@ class Record:
         ``RDFRecordMixin``). If the record is not lazy, this method does
         nothing.'''
         pass
+
+    @property
+    def iri(self) -> Optional[str]:
+        '''A stable IRI based on the `identifier` attribute. `None` if
+        the `identifier` attribute is not set.'''
+        if self.identifier:
+            return self.from_reader.identifier_to_iri(self.identifier)
+        else:
+            return None
+
+    @property
+    def subject_node(self) -> Node:
+        '''A subject node based on the `identifier` attribute. If the 
+        `identifier` attribute is not set, a blank node.'''
+        iri = self.iri
+        if iri is not None:
+            return URIRef(iri)
+        else:
+            # IRI is not available; return a consistent blank node
+            if not self._bnode:
+                self._bnode = BNode()
+            return self._bnode
 
 
 class BibliographicalRecord(Record):

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -102,11 +102,13 @@ class SparqlReader(Reader):
     endpoint: str
     name_predicate: str
     filter: Optional[str] = None
+    prepared_query: Optional[str]
 
-    def transform_query(self, query: str):
+    @classmethod
+    def transform_query(cls, query: str):
         return prepare_listing_query(
-            name_predicate=self.name_predicate,
-            filter=self.filter,
+            name_predicate=cls.name_predicate,
+            filter=cls.filter,
             query=query
         )
 

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -110,6 +110,10 @@ class SparqlReader(Reader):
             query=query
         )
 
+    @classmethod
+    def get_by_id(cls, identifier: str) -> Record:
+        return cls._create_lazy_record(identifier)
+
     def fetch(self):
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
@@ -144,7 +148,7 @@ class SparqlReader(Reader):
 
     @classmethod
     @abstractmethod
-    def _create_lazy_record(cls, iri: str, name: str) -> Record:
+    def _create_lazy_record(cls, iri: str, name: Optional[str]=None) -> Record:
         """Create a Record/LazyRecordMixin record object.
 
         This is the lazy record that is created after running the SPARQL

--- a/edpop_explorer/sql.py
+++ b/edpop_explorer/sql.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+from edpop_explorer import PreparedQuery
+
+
+@dataclass
+class SQLPreparedQuery(PreparedQuery):
+    where_statement: str
+    arguments: List[Union[str, int]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ edpopx = "edpop_explorer.__main__:main"
 pythonpath = [
   "edpop_explorer"
 ]
+markers = ["requests: mark a test as performing real API requests"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   'pyyaml',
   'rdflib>=7.0.0,<8',
   'Pygments',
+  'xmltodict>=0.13.0',
 ]
 
 description = "Common interface to multiple library catalogues and bibliographical databases"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption('--requests', action='store_true', dest="requests",
+                 default=False, help="enable tests with real API requests")
+
+def pytest_configure(config):
+    if not config.option.requests:
+        setattr(config.option, 'markexpr', 'not requests')

--- a/tests/test_allreaders.py
+++ b/tests/test_allreaders.py
@@ -18,7 +18,7 @@ def test_instantiate(readercls: Type[Reader]):
 
 @pytest.mark.parametrize("readercls", ALL_READERS)
 def test_transform_query(readercls: Type[Reader]):
-    assert isinstance(readercls.transform_query("testquery"), str)
+    readercls.transform_query("testquery")
 
 
 @pytest.mark.parametrize("readercls", ALL_READERS)

--- a/tests/test_allreaders.py
+++ b/tests/test_allreaders.py
@@ -1,0 +1,37 @@
+'''Test all readers for basic sanity, without invoking methods that could
+access the internet or manipulate files.'''
+
+import pytest
+from typing import Type
+
+from edpop_explorer import Reader, ReaderError
+from edpop_explorer.readers import ALL_READERS
+
+
+@pytest.mark.parametrize("readercls", ALL_READERS)
+def test_instantiate(readercls: Type[Reader]):
+    # Test if all concrete reader classes can be instantiated: all abstract
+    # methods should have been overridden and there should be no errors
+    # in the class definition.
+    readercls()
+
+
+@pytest.mark.parametrize("readercls", ALL_READERS)
+def test_transform_query(readercls: Type[Reader]):
+    assert isinstance(readercls.transform_query("testquery"), str)
+
+
+@pytest.mark.parametrize("readercls", ALL_READERS)
+def test_identifier_to_iri(readercls: Type[Reader]):
+    # Converting an identifier to an IRI should always be possible
+    assert isinstance(readercls.identifier_to_iri("123"), str)
+
+
+@pytest.mark.parametrize("readercls", ALL_READERS)
+def test_iri_to_identifier(readercls: Type[Reader]):
+    # This is likely to fail, but if it fails it should raise a ReaderError
+    # or derivative
+    try:
+        readercls.iri_to_identifier("http://example.com/record/1")
+    except ReaderError:
+        pass

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -19,7 +19,8 @@ class SimpleReader(Reader):
     def fetch_next(self):
         pass
 
-    def transform_query(self, query):
+    @classmethod
+    def transform_query(cls, query):
         return query.capitalize()
 
     def get_by_id(self, identifier: str) -> Record:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2,8 +2,9 @@ import pytest
 
 from rdflib import URIRef, RDF
 
-from edpop_explorer import Record, Reader, ReaderError
-from edpop_explorer import EDPOPREC
+from edpop_explorer import (
+    Record, Reader, ReaderError, EDPOPREC, GetByIdBasedOnQueryMixin
+)
 
 
 class SimpleReader(Reader):
@@ -40,9 +41,11 @@ def test_iri_to_identifier():
     iri = "http://example.com/records/reader/1"
     assert SimpleReader.iri_to_identifier(iri) == "1"
 
+
 def test_iri_to_identifier_invalid():
     with pytest.raises(ReaderError):
         SimpleReader.iri_to_identifier("invalid/1")
+
 
 def test_iri_to_identifier_and_vv_noprefixset():
     with pytest.raises(ReaderError):
@@ -52,7 +55,43 @@ def test_iri_to_identifier_and_vv_noprefixset():
     with pytest.raises(ReaderError):
         SimpleReaderNoIRIPrefix.identifier_to_iri("1")
 
+
 def test_identifier_to_iri():
     expected_iri = "http://example.com/records/reader/1"
     assert SimpleReader.identifier_to_iri("1") == expected_iri
 
+
+class SimpleReaderGetByIdBasedOnQuery(GetByIdBasedOnQueryMixin, SimpleReader):
+    @classmethod
+    def _prepare_get_by_id_query(cls, identifier: str) -> str:
+        return f"get {identifier}"
+
+    def fetch(self):
+        if not self.prepared_query:
+            return
+        if self.prepared_query == "get manymatching":
+            self.records = [Record(self.__class__), Record(self.__class__)]
+            self.number_fetched = self.number_of_results = 2
+        elif self.prepared_query == "get nonematching":
+            self.records = []
+            self.number_fetched = self.number_of_results = 0
+        elif self.prepared_query.startswith("get "):
+            record = Record(self.__class__)
+            record.identifier = self.prepared_query[4:]
+            self.records = [record]
+            self.number_fetched = self.number_of_results = 1
+
+
+def test_getbyidbasedonquerymixin():
+    record = SimpleReaderGetByIdBasedOnQuery.get_by_id("10")
+    assert record.identifier == "10"
+
+
+def test_getbyidbasedonquerymixin_multiplereturned():
+    with pytest.raises(ReaderError):
+       SimpleReaderGetByIdBasedOnQuery.get_by_id("manymatching")
+
+
+def test_getbyidbasedonquerymixin_nonereturned():
+    with pytest.raises(ReaderError):
+       SimpleReaderGetByIdBasedOnQuery.get_by_id("nonematching")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,11 +1,14 @@
+import pytest
+
 from rdflib import URIRef, RDF
 
-from edpop_explorer import Record, Reader
+from edpop_explorer import Record, Reader, ReaderError
 from edpop_explorer import EDPOPREC
 
 
 class SimpleReader(Reader):
     CATALOG_URIREF = URIRef('http://example.com/reader')
+    IRI_PREFIX = "http://example.com/records/reader/"
 
     def fetch(self):
         self.records = [Record(self.__class__)]
@@ -18,8 +21,38 @@ class SimpleReader(Reader):
     def transform_query(self, query):
         return query.capitalize()
 
+    def get_by_id(self, identifier: str) -> Record:
+        record = Record(self.__class__)
+        record.identifier = identifier
+        return record
+
+class SimpleReaderNoIRIPrefix(SimpleReader):
+    IRI_PREFIX = None
+
 
 def test_catalog_to_graph():
     reader = SimpleReader()
     g = reader.catalog_to_graph()
     assert (reader.CATALOG_URIREF, RDF.type, EDPOPREC.Catalog) in g
+
+
+def test_iri_to_identifier():
+    iri = "http://example.com/records/reader/1"
+    assert SimpleReader.iri_to_identifier(iri) == "1"
+
+def test_iri_to_identifier_invalid():
+    with pytest.raises(ReaderError):
+        SimpleReader.iri_to_identifier("invalid/1")
+
+def test_iri_to_identifier_and_vv_noprefixset():
+    with pytest.raises(ReaderError):
+        SimpleReaderNoIRIPrefix.iri_to_identifier(
+            "http://example.com/records/reader/1"
+        )
+    with pytest.raises(ReaderError):
+        SimpleReaderNoIRIPrefix.identifier_to_iri("1")
+
+def test_identifier_to_iri():
+    expected_iri = "http://example.com/records/reader/1"
+    assert SimpleReader.identifier_to_iri("1") == expected_iri
+

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -9,6 +9,7 @@ from edpop_explorer.record import BiographicalRecord
 
 class SimpleReader(Reader):
     CATALOG_URIREF = URIRef('http://example.com/reader')
+    IRI_PREFIX = "http://example.com/records/reader/"
 
 
 class SimpleRecord(Record):
@@ -30,6 +31,20 @@ def basic_record():
     record.link = 'http://example.com'
     record.identifier = '123'
     return record
+
+
+def test_iri(basic_record: SimpleRecord):
+    assert basic_record.iri == "http://example.com/records/reader/123"
+
+
+def test_iri_empty(basic_record: SimpleRecord):
+    basic_record.identifier = None
+    assert basic_record.iri is None
+
+
+def test_subject_node(basic_record: SimpleRecord):
+    assert basic_record.subject_node == \
+            URIRef("http://example.com/records/reader/123")
 
 
 def test_to_graph_empty():

--- a/tests/test_srureader.py
+++ b/tests/test_srureader.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data
+from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data, Record
 
 
 TESTDATA = json.load(open(Path(__file__).parent / 'TESTDATA', 'r'))
@@ -20,6 +20,11 @@ class MockReader(SRUMarc21BibliographicalReader):
     @classmethod
     def _get_identifier(cls, data: Marc21Data) -> Optional[str]:
         return 'id'
+
+    @classmethod
+    def get_by_id(cls, identifier: str) -> Record:
+        # Placeholder, remove when implemented for SRU readers
+        return Record(cls)
 
 
 class TestSRUMarc21BibliographicalReader:

--- a/tests/test_srureader.py
+++ b/tests/test_srureader.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data, Record
+from edpop_explorer import SRUMarc21BibliographicalReader, Marc21Data
 
 
 TESTDATA = json.load(open(Path(__file__).parent / 'TESTDATA', 'r'))

--- a/tests/test_srureader.py
+++ b/tests/test_srureader.py
@@ -10,7 +10,8 @@ TESTDATA = json.load(open(Path(__file__).parent / 'TESTDATA', 'r'))
 
 
 class MockReader(SRUMarc21BibliographicalReader):
-    def transform_query(self, query: str) -> str:
+    @classmethod
+    def transform_query(cls, query: str) -> str:
         return query
 
     @classmethod
@@ -20,11 +21,6 @@ class MockReader(SRUMarc21BibliographicalReader):
     @classmethod
     def _get_identifier(cls, data: Marc21Data) -> Optional[str]:
         return 'id'
-
-    @classmethod
-    def get_by_id(cls, identifier: str) -> Record:
-        # Placeholder, remove when implemented for SRU readers
-        return Record(cls)
 
 
 class TestSRUMarc21BibliographicalReader:


### PR DESCRIPTION
* Requesting by identifier is possible. In the CLI, this can be done by typing `<readername> identifier <identifier>`
* All records have an URI now based on their identifier (closes #23)
* Requesting is also possible by URI (closes #22)

#13 is now also more or less completed, so let's say closes #13.

The API should now be more or less finished for basic use in the VRE.