### PR TITLE
Adjustments to fetch API

### DIFF
--- a/edpop_explorer/edpopxshell.py
+++ b/edpop_explorer/edpopxshell.py
@@ -74,7 +74,7 @@ class EDPOPXShell(cmd2.Cmd):
             self.perror('All records have been shown')
         else:
             if self.reader.number_fetched - self.shown < self.RECORDS_PER_PAGE:
-                self.reader.fetch_next()
+                self.reader.fetch()
             self.shown += self._show_records(self.reader.records,
                                              self.shown,
                                              self.RECORDS_PER_PAGE)
@@ -195,7 +195,7 @@ class EDPOPXShell(cmd2.Cmd):
         'Koninklijke Bibliotheek'
         self._query(KBReader, args)
 
-    def _show_records(self, records: List[Record],
+    def _show_records(self, records: List[Optional[Record]],
                       start: int,
                       limit=math.inf) -> int:
         """Show the records from start, with limit as the maximum number

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -92,7 +92,7 @@ class Reader(ABC):
         This functionality may be ignored by readers that can only load 
         all records at once; generally these are readers that return lazy 
         records."""
-        if self.records is not None:
+        if self.number_of_results is not None:
             raise ReaderError(
                 "adjust_start_record should not be called after fetching."
             )

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, List, Union
 from rdflib import Graph, RDF, URIRef
+from urllib.parse import quote, unquote
 
 from edpop_explorer import (
     EDPOPREC, BIBLIOGRAPHICAL, BIOGRAPHICAL, bind_common_namespaces
@@ -131,7 +132,7 @@ class Reader(ABC):
                 f"Cannot convert identifier to IRI: {__class__}.IRI_PREFIX "
                 "not a string."
             )
-        return cls.IRI_PREFIX + identifier
+        return cls.IRI_PREFIX + quote(identifier)
 
     @classmethod
     def iri_to_identifier(cls, iri: str) -> str:
@@ -141,7 +142,7 @@ class Reader(ABC):
                 "not a string."
             )
         if iri.startswith(cls.IRI_PREFIX):
-            return iri[len(cls.IRI_PREFIX):]
+            return unquote(iri[len(cls.IRI_PREFIX):])
         else:
             raise ReaderError(
                 f"Cannot convert IRI {iri} to identifier: IRI does not start "

--- a/edpop_explorer/reader.py
+++ b/edpop_explorer/reader.py
@@ -38,9 +38,10 @@ class Reader(ABC):
     number_of_results: Optional[int] = None
     '''The total number of results for the query, including those
     that have not been fetched yet.'''
-    number_fetched: Optional[int] = None
-    '''The number of results that has been fetched so far.'''
-    records: List[Record]
+    number_fetched: int = 0
+    '''The number of results that has been fetched so far, or 0 if
+    no fetch has been performed yet.'''
+    records: List[Optional[Record]]
     '''The records that have been fetched as instances of
     (a subclass of) ``Record``.'''
     prepared_query: Optional[PreparedQueryType] = None
@@ -56,6 +57,9 @@ class Reader(ABC):
     `identifier_to_iri` and `iri_to_identifier` methods have to be
     overridden.'''
     _graph: Optional[Graph] = None
+
+    def __init__(self):
+        self.records = []
 
     @classmethod
     @abstractmethod
@@ -77,14 +81,35 @@ class Reader(ABC):
         attribute.'''
         self.prepared_query = query
 
-    @abstractmethod
-    def fetch(self):
-        '''Perform an initial query.'''
-        pass
+    def adjust_start_record(self, start_number: int) -> None:
+        """Skip the given number of first records and start fetching 
+        afterwards. Should be calling before the first time calling
+        ``fetch()``. The missing records in the ``records`` attribute
+        will be filled by ``None``s. The ``number_fetched`` attribute
+        will be adjusted as if the first records have been fetched.
+        This is mainly useful if the skipped records have already been 
+        fetched but the original ``Reader`` object is not available anymore. 
+        This functionality may be ignored by readers that can only load 
+        all records at once; generally these are readers that return lazy 
+        records."""
+        if self.records is not None:
+            raise ReaderError(
+                "adjust_start_record should not be called after fetching."
+            )
+        self.number_fetched = start_number
+        self.records = [None for _ in range(start_number)]
 
     @abstractmethod
-    def fetch_next(self):
-        '''Perform a subsequental query.'''
+    def fetch(
+            self, number: Optional[int] = None
+    ):
+        '''Perform an initial or subsequent query. Most readers fetch
+        a limited number of records at once -- this number depends on
+        the reader but it may be adjusted using the ``number`` argument.
+        Other readers fetch all records at once and ignore the ``number``
+        argument. After fetching, the ``records`` and ``number_fetched``
+        attributes are adjusted and the ``number_of_results`` attribute
+        will be available.'''
         pass
 
     @classmethod
@@ -146,6 +171,13 @@ class Reader(ABC):
         bind_common_namespaces(g)
         
         return g
+
+    @property
+    def fetching_exhausted(self) -> bool:
+        """Return ``True`` if all results have been fetched. This is currently
+        implemented by simply checking if the ``number_of_results`` and
+        ``number_fetched`` attributes are equal."""
+        return self.number_fetched == self.number_of_results
 
 
 class GetByIdBasedOnQueryMixin(ABC):

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -92,7 +92,7 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             # author is tuple of author code and author name
             record.contributors.append(Field(author[1]))
 
-    def fetch(self) -> None:
+    def fetch(self, number: Optional[int] = None) -> None:
         self.prepare_data()
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')

--- a/edpop_explorer/readers/fbtee.py
+++ b/edpop_explorer/readers/fbtee.py
@@ -96,7 +96,8 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
         self.prepare_data()
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
-
+        if self.fetching_exhausted:
+            return
         cur = self.con.cursor()
         columns = [x[1] for x in cur.execute('PRAGMA table_info(books)')]
         res = cur.execute(
@@ -133,7 +134,3 @@ class FBTEEReader(GetByIdBasedOnQueryMixin, Reader):
             self._add_fields(record)
         self.number_of_results = len(self.records)
         self.number_fetched = self.number_of_results
-        self.fetching_exhausted = True
-
-    def fetch_next(self):
-        pass

--- a/edpop_explorer/readers/sbtireader.py
+++ b/edpop_explorer/readers/sbtireader.py
@@ -126,22 +126,12 @@ class SBTIReader(Reader):
         return query
 
     def fetch(self) -> None:
-        self.records = []
         if self.prepared_query is None:
             raise ReaderError('First call prepare_query')
-        results = self._perform_query(0)
-        self.records.extend(results)
-        self.number_fetched = len(self.records)
-        if self.number_fetched == self.number_of_results:
-            self.fetching_exhausted = True
-
-    def fetch_next(self) -> None:
-        # TODO: can be merged with fetch method
         if self.fetching_exhausted:
             return
-        start_record = len(self.records) + 1
+        start_record = len(self.records)
         results = self._perform_query(start_record)
         self.records.extend(results)
         self.number_fetched = len(self.records)
-        if self.number_fetched == self.number_of_results:
-            self.fetching_exhausted = True
+

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -74,6 +74,8 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
 
         if not self.prepared_query:
             raise ReaderError('No query has been set')
+        if self.fetching_exhausted:
+            return
 
         cur = self.con.cursor()
         columns = [x[1] for x in cur.execute('PRAGMA table_info(editions)')]
@@ -95,10 +97,6 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
             self.records.append(record)
         self.number_of_results = len(self.records)
         self.number_fetched = self.number_of_results
-        self.fetching_exhausted = True
-
-    def fetch_next(self):
-        pass
 
     def _convert_record(self, data: dict) -> BibliographicalRecord:
         record = BibliographicalRecord(from_reader=self.__class__)

--- a/edpop_explorer/readers/ustc.py
+++ b/edpop_explorer/readers/ustc.py
@@ -66,7 +66,7 @@ class USTCReader(GetByIdBasedOnQueryMixin, Reader):
             arguments=[identifier_int]
         )
 
-    def fetch(self) -> None:
+    def fetch(self, number: Optional[int] = None) -> None:
         self.prepare_data()
 
         # This method fetches all records immediately, because the data is

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -116,7 +116,7 @@ class SparqlReader(Reader):
     def get_by_id(cls, identifier: str) -> Record:
         return cls._create_lazy_record(identifier)
 
-    def fetch(self):
+    def fetch(self, number: Optional[int] = None):
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
         if self.fetching_exhausted:

--- a/edpop_explorer/sparqlreader.py
+++ b/edpop_explorer/sparqlreader.py
@@ -119,6 +119,8 @@ class SparqlReader(Reader):
     def fetch(self):
         if not self.prepared_query:
             raise ReaderError('First call prepare_query method')
+        if self.fetching_exhausted:
+            return
         wrapper = SPARQLWrapper(self.endpoint)
         wrapper.setReturnFormat(JSONFormat)
         wrapper.setQuery(self.prepared_query)
@@ -137,9 +139,6 @@ class SparqlReader(Reader):
             name = result['name']['value']
             self.records.append(self._create_lazy_record(iri, name))
         self.number_fetched = self.number_of_results
-
-    def fetch_next(self):
-        pass
 
     @classmethod
     @abstractmethod

--- a/tests/test_allreaders.py
+++ b/tests/test_allreaders.py
@@ -50,9 +50,13 @@ def test_catalog_to_graph(readercls: Type[Reader]):
 def test_realrequest(readercls: Type[Reader]):
     reader = readercls()
     reader.prepare_query("gruninger")
-    reader.fetch()
+    reader.fetch(5)
     assert reader.number_of_results is not None
     assert reader.number_fetched == len(reader.records)
+    if not reader.fetching_exhausted:
+        # Assert that maximum number of results is respected if reader does
+        # not fetch all results at once
+        assert reader.number_fetched <= 5
     assert reader.number_of_results >= reader.number_fetched
     if reader.number_fetched > 0:
         record = reader.records[0]
@@ -71,7 +75,7 @@ def test_realrequest(readercls: Type[Reader]):
             )
     # Perform a second fetch
     fetched_before = reader.number_fetched
-    reader.fetch()
+    reader.fetch()  # Do not pass number of results to test that as well
     # If not all records had been fetched already, more records
     # should be available now. Otherwise, nothing should have
     # changed.


### PR DESCRIPTION
Adjust fetch API to support some requirements for the EDPOP VRE:

* Start fetching from an offset instead of from the beginning (this is needed because `Reader` objects won't be shared across API requests from the frontend, since every request might run in a different process)
* Adjust the maximum number of new results to fetch each time (this is needed to allow the user to control how many records they want to see)
* Merge the `fetch()` and `fetch_next()` methods